### PR TITLE
Prefer chest over backback...

### DIFF
--- a/src/main/java/com/tattyseal/compactstorage/GuiHandler.java
+++ b/src/main/java/com/tattyseal/compactstorage/GuiHandler.java
@@ -37,7 +37,7 @@ public class GuiHandler implements IGuiHandler
 
                 if (entity instanceof IChest)
                 {
-                    chest = (IChest) world.getTileEntity(pos);
+                    chest = (IChest)entity;
                 }
                 else if (player.getHeldItem(EnumHand.MAIN_HAND).getItem().equals(CompactStorage.backpack))
                 {
@@ -65,14 +65,18 @@ public class GuiHandler implements IGuiHandler
                  // chest or backpack
                 IChest chest;
 
-                if(player.getHeldItem(EnumHand.MAIN_HAND).getItem() == CompactStorage.backpack)
+                net.minecraft.tileentity.TileEntity entity = world.getTileEntity(pos);
+
+                if (entity instanceof IChest)
+                {
+                    chest = (IChest)entity;
+                }
+                else if (player.getHeldItem(EnumHand.MAIN_HAND).getItem().equals(CompactStorage.backpack))
                 {
                     chest = new InventoryBackpack(player.getHeldItem(EnumHand.MAIN_HAND));
                 }
-                else
-                {
-                    chest = (IChest) world.getTileEntity(pos);
-                }
+                // this shouldn't happen
+                else return null;
 
                 return new GuiChest((Container) getServerGuiElement(ID, player, world, x, y, z), chest, world, player, pos);
             }

--- a/src/main/java/com/tattyseal/compactstorage/GuiHandler.java
+++ b/src/main/java/com/tattyseal/compactstorage/GuiHandler.java
@@ -33,14 +33,18 @@ public class GuiHandler implements IGuiHandler
                 // chest or backpack
                 IChest chest;
 
-                if(player.getHeldItem(EnumHand.MAIN_HAND).getItem().equals(CompactStorage.backpack))
-                {
-                    chest = new InventoryBackpack(player.getHeldItem(EnumHand.MAIN_HAND));
-                }
-                else
+                net.minecraft.tileentity.TileEntity entity = world.getTileEntity(pos);
+
+                if (entity instanceof IChest)
                 {
                     chest = (IChest) world.getTileEntity(pos);
                 }
+                else if (player.getHeldItem(EnumHand.MAIN_HAND).getItem().equals(CompactStorage.backpack))
+                {
+                    chest = new InventoryBackpack(player.getHeldItem(EnumHand.MAIN_HAND));
+                }
+                // this shouldn't happen
+                else return null;
 
                 return new ContainerChest(world, chest, player, pos);
             }


### PR DESCRIPTION
Without this branch, trying to open a (compact storage) chest while holding a backpack, will result in opening the backpack. It appears that this behavior was not intended, so accept this PR to fix it, that is, to prioritize opening the chest.